### PR TITLE
Updated serialize subpackage

### DIFF
--- a/default_collector_test.go
+++ b/default_collector_test.go
@@ -50,7 +50,7 @@ func TestBuildeDefaultrDataCollector(t *testing.T) {
 data_collector:
   name: "default"
   args:
-    path: "./test/default_collector_test"
+    path: "file://test/default_collector_test"
     aggregate: true
     compress: true
 source:

--- a/serialize/detect.go
+++ b/serialize/detect.go
@@ -1,0 +1,20 @@
+package serialize
+
+import (
+	"fmt"
+	"strings"
+)
+
+func DetectSerializer(path string) (serializer Serializer, err error) {
+	if strings.HasPrefix(path, "hdfs://") {
+		serializer = NewHDFSSerializer(path)
+	} else if strings.HasPrefix(path, "http://") || strings.HasPrefix(path, "https://") {
+		serializer = &HTTPSerializer{}
+	} else if strings.HasPrefix(path, "file://") {
+		// Local
+		serializer = &LocalSerializer{}
+	} else {
+		err = fmt.Errorf("Unknown protocol in path: %v", path)
+	}
+	return
+}

--- a/serialize/detect_test.go
+++ b/serialize/detect_test.go
@@ -1,0 +1,80 @@
+package serialize
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func test(t *testing.T, str string, obj Serializer) {
+	require := require.New(t)
+	s, err := DetectSerializer(str)
+	require.Nil(err)
+	require.Equal(reflect.TypeOf(s), reflect.TypeOf(obj))
+}
+
+func TestDetectHDFS(t *testing.T) {
+	// Base
+	str := "hdfs://example.com/"
+	test(t, str, &HDFSSerializer{})
+
+	// With port
+	str = "hdfs://example.com:31121/"
+	test(t, str, &HDFSSerializer{})
+
+	// Base with path
+	str = "hdfs://example.com/test"
+	test(t, str, &HDFSSerializer{})
+
+	// Port with path
+	str = "hdfs://example.com:31121/test"
+	test(t, str, &HDFSSerializer{})
+}
+
+func TestDetectHTTP(t *testing.T) {
+	str := "http://example.com/"
+	test(t, str, &HTTPSerializer{})
+
+	// With port
+	str = "http://example.com:31121/"
+	test(t, str, &HTTPSerializer{})
+
+	// Base with path
+	str = "http://example.com/test"
+	test(t, str, &HTTPSerializer{})
+
+	// Port with path
+	str = "http://example.com:31121/test"
+	test(t, str, &HTTPSerializer{})
+
+	// Now HTTPS
+	str = "https://example.com/"
+	test(t, str, &HTTPSerializer{})
+
+	// With port
+	str = "https://example.com:31121/"
+	test(t, str, &HTTPSerializer{})
+
+	// Base with path
+	str = "https://example.com/test"
+	test(t, str, &HTTPSerializer{})
+
+	// Port with path
+	str = "https://example.com:31121/test"
+	test(t, str, &HTTPSerializer{})
+}
+
+func TestDetectLocal(t *testing.T) {
+	str := "file://test"
+	test(t, str, &LocalSerializer{})
+
+	str = "file://test/"
+	test(t, str, &LocalSerializer{})
+
+	str = "file:///test"
+	test(t, str, &LocalSerializer{})
+
+	str = "file:///test/"
+	test(t, str, &LocalSerializer{})
+}

--- a/serialize/hdfs.go
+++ b/serialize/hdfs.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/gurupras/go-easyfiles"
 	"github.com/gurupras/go-easyfiles/easyhdfs"
+	log "github.com/sirupsen/logrus"
 )
 
 type HDFSSerializer struct {
@@ -16,9 +17,17 @@ type HDFSSerializer struct {
 }
 
 func NewHDFSSerializer(addr string) *HDFSSerializer {
-	return &HDFSSerializer{
-		Addr: stripHDFSPrefix(addr),
+	return &HDFSSerializer{parseHDFSAddr(addr)}
+}
+
+func parseHDFSAddr(path string) string {
+	path = stripHDFSPrefix(path)
+	// Address is up to first '/'
+	idx := strings.Index(path, "/")
+	if idx == -1 {
+		idx = len(path)
 	}
+	return path[:idx]
 }
 
 func stripHDFSPrefix(addr string) string {
@@ -28,34 +37,50 @@ func stripHDFSPrefix(addr string) string {
 	return addr
 }
 
+func (h *HDFSSerializer) OutPath(path string) (string, error) {
+	hostnameIdx := strings.Index(path, parseHDFSAddr(h.Addr))
+	if hostnameIdx == -1 {
+		return "", fmt.Errorf("Path does not contain HDFS address prefix '%v'", h.Addr)
+	} else {
+		hostnameIdx += len(h.Addr)
+	}
+	return path[hostnameIdx:], nil
+}
+
 func (h *HDFSSerializer) Serialize(obj interface{}, filename string) error {
 	// FIXME: We should use a pool of connections
 	// This will blow up the number of connections if there are a large
 	// number of goroutines.
-	fs := easyhdfs.NewHDFSFileSystem(h.Addr)
+	outPath, err := h.OutPath(filename)
+	if err != nil {
+		return err
+	}
+	log.Debugf("OutPath=%v\n", outPath)
 
-	filename = stripHDFSPrefix(filename)
 	fileType := easyfiles.GZ_FALSE
-	if strings.HasSuffix(filename, ".gz") {
+	if strings.HasSuffix(outPath, ".gz") {
 		fileType = easyfiles.GZ_TRUE
 	}
 
+	fs := easyhdfs.NewHDFSFileSystem(h.Addr)
 	//Mkdirs
-	outdir := path.Dir(filename)
-	err := fs.Makedirs(outdir)
-	if err != nil {
-		return fmt.Errorf("Failed to create directory: %v: %v", outdir, err)
+	outdir := path.Dir(outPath)
+	if exists, _ := fs.Exists(outdir); !exists {
+		err := fs.Makedirs(outdir)
+		if err != nil {
+			return fmt.Errorf("Failed to create directory: %v: %v", outdir, err)
+		}
 	}
 
-	file, err := fs.Open(filename, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, fileType)
+	file, err := fs.Open(outPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, fileType)
 	if err != nil {
-		return fmt.Errorf("Failed to open file: %v: %v", filename, err)
+		return fmt.Errorf("Failed to open file: %v: %v", outPath, err)
 	}
 	defer file.Close()
 
 	writer, err := file.Writer(0)
 	if err != nil {
-		return fmt.Errorf("Failed to get writer to file: %v: %v", filename, err)
+		return fmt.Errorf("Failed to get writer to file: %v: %v", outPath, err)
 	}
 	defer writer.Close()
 	defer writer.Flush()
@@ -66,7 +91,7 @@ func (h *HDFSSerializer) Serialize(obj interface{}, filename string) error {
 	}
 
 	if _, err := writer.Write(b); err != nil {
-		return fmt.Errorf("Failed to write json bytes to file: %v: %v", filename, err)
+		return fmt.Errorf("Failed to write json bytes to file: %v: %v", outPath, err)
 	}
 	return nil
 }

--- a/serialize/http_test.go
+++ b/serialize/http_test.go
@@ -2,16 +2,12 @@ package serialize
 
 import (
 	"encoding/json"
-	"net/http"
 	"os"
 	"reflect"
-	"sync"
 	"testing"
 	"time"
 
-	"github.com/gorilla/mux"
 	"github.com/gurupras/go-easyfiles"
-	"github.com/gurupras/go-stoppable-net-listener"
 	"github.com/stretchr/testify/require"
 )
 
@@ -20,21 +16,7 @@ func TestHTTPSerialize(t *testing.T) {
 
 	httpReceiver := NewHTTPReceiver("test")
 
-	r := mux.NewRouter()
-	r.HandleFunc("/upload/{relpath:[\\S+/]+}", httpReceiver.Handle)
-	http.Handle("/", r)
-
-	wg := sync.WaitGroup{}
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		server := http.Server{}
-		snl, err := stoppablenetlistener.New(41121)
-		require.Nil(err)
-		snl.Timeout = 100 * time.Millisecond
-		server.Serve(snl)
-	}()
-
+	go httpReceiver.RunHTTPReceiver(41121)
 	time.Sleep(100 * time.Millisecond)
 
 	// Now upload some data

--- a/serialize/local.go
+++ b/serialize/local.go
@@ -2,8 +2,10 @@ package serialize
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"path"
+	"strings"
 
 	"github.com/gurupras/go-easyfiles"
 )
@@ -11,8 +13,21 @@ import (
 type LocalSerializer struct {
 }
 
+func (h *LocalSerializer) OutPath(path string) (string, error) {
+	// Remove file://
+	if strings.HasPrefix(path, "file://") {
+		return path[7:], nil
+	} else {
+		return "", fmt.Errorf("Path '%v' does not contain 'file://'", path)
+	}
+}
+
 func (h *LocalSerializer) Serialize(obj interface{}, filename string) error {
-	dir := path.Dir(filename)
+	outPath, err := h.OutPath(filename)
+	if err != nil {
+		return err
+	}
+	dir := path.Dir(outPath)
 	if !easyfiles.Exists(dir) {
 		if err := easyfiles.Makedirs(dir); err != nil {
 			return err
@@ -22,7 +37,7 @@ func (h *LocalSerializer) Serialize(obj interface{}, filename string) error {
 	if b, err := json.MarshalIndent(obj, "", "    "); err != nil {
 		return err
 	} else {
-		f, err := easyfiles.Open(filename, os.O_CREATE|os.O_WRONLY, easyfiles.GZ_UNKNOWN)
+		f, err := easyfiles.Open(outPath, os.O_CREATE|os.O_WRONLY, easyfiles.GZ_UNKNOWN)
 		if err != nil {
 			return err
 		}

--- a/serialize/local_test.go
+++ b/serialize/local_test.go
@@ -22,7 +22,7 @@ func TestLocalSerialize(t *testing.T) {
 	filename := "test-local-serializer.gz"
 	filePath := filepath.Join(outdir, filename)
 
-	err := serializer.Serialize(data, filePath)
+	err := serializer.Serialize(data, "file://"+filePath)
 	require.Nil(err)
 	defer os.RemoveAll(outdir)
 

--- a/serialize/serialize.go
+++ b/serialize/serialize.go
@@ -3,4 +3,5 @@ package serialize
 // Serializer is an interface for serializing objects as JSON to a path.
 type Serializer interface {
 	Serialize(obj interface{}, path string) error
+	OutPath(path string) (string, error)
 }


### PR DESCRIPTION
    - Added DetectSerializer() to API
    - Updated NewHDFSSerializer to expect addr in format: (hdfs://)?hdfs_server_addr/?
    - Added check in HDFS before calling Makedirs
    - Added a default HTTP receiver
    - Updated Serializer API with OutPath() to do the path processing
        - This is can be used in tests to ensure sane paths lest you end up destroying filesystems
